### PR TITLE
avoid possible use of uninitialized intf_addr in nmrp_do()

### DIFF
--- a/nmrp.c
+++ b/nmrp.c
@@ -360,7 +360,7 @@ int nmrp_do(struct nmrpd_args *args)
 	struct ethsock *sock;
 	struct ethsock_ip_undo *ip_undo = NULL;
 	struct ethsock_arp_undo *arp_undo = NULL;
-	uint32_t intf_addr;
+	uint32_t intf_addr = 0;
 	void (*sigh_orig)(int);
 	struct in_addr ipaddr;
 	struct in_addr ipmask;


### PR DESCRIPTION
 Silences a warning by gcc:

```
  nmrp.c:462:7: warning: ‘intf_addr’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  462 |   if (ethsock_ip_add(sock, intf_addr, ipmask.s_addr, &ip_undo) != 0) {
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```