### PR TITLE
support compiling outside of git checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC ?= gcc
 PREFIX ?= /usr/local
-VERSION = $(shell git describe --always | tail -c +2)
+VERSION := $(shell if [ -d .git ] && which git 2>&1 > /dev/null; then git describe --always | tail -c +2; else echo $$STANDALONE_VERSION; fi)
 LIBS = -lpcap
 CFLAGS += -Wall -g -DNMRPFLASH_VERSION=\"$(VERSION)\"
 LDFLAGS += $(LIBS)


### PR DESCRIPTION
When building nmrpflash for Debian, there is no 'git' command available,
and there is no '.git' directory either. This makes the build emit
warnings from the $(shell) calls in VERSION variable in the Makefile
and breaks the '-V' option.

The change in this patch accounts for missing 'git' command and resorts
to using a STANDALONE_VERSION environment variable which in turn is
provided by the package build mechanics.

This change has no effect when the git command is available and the
'.git' directory is present.