### PR TITLE
Improve cross-building by honoring PKG_CONFIG from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 CC ?= gcc
+PKG_CONFIG ?= pkg-config
 PREFIX ?= /usr/local
 VERSION = $(shell git describe --always | tail -c +2)
 LIBS = -lpcap
@@ -6,8 +7,8 @@ CFLAGS += -Wall -g -DNMRPFLASH_VERSION=\"$(VERSION)\"
 LDFLAGS += $(LIBS)
 
 ifeq ($(shell uname -s),Linux)
-	CFLAGS += $(shell pkg-config libnl-route-3.0 --cflags)
-	LIBS += $(shell pkg-config libnl-route-3.0 --libs)
+	CFLAGS += $(shell $(PKG_CONFIG) libnl-route-3.0 --cflags)
+	LIBS += $(shell $(PKG_CONFIG) libnl-route-3.0 --libs)
 endif
 
 nmrpflash_OBJ = nmrp.o tftp.o ethsock.o main.o util.o


### PR DESCRIPTION
This is in response to Debian bug #960165 by Helmut Grohne.
<https://bugs.debian.org/960165>

When cross-building, another pkg-config is used that accounts for the target
architecture.

The patch makes it possible to supply that via the PKG_CONFIG environment
variable and defaults to 'pkg-config' so no such variable defaults to
native build.