### PR TITLE
Confirm work on my NETGEAR R6100

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ nmrpflash - Netgear Unbrick Utility
 
 `nmrpflash` uses Netgear's [NMRP protocol](http://www.chubb.wattle.id.au/PeterChubb/nmrp.html)
 to flash a new firmware image to a compatible device. It has been successfully used on a Netgear
-EX2700, EX6120, EX6150v2, DNG3700v2, R6220, R7000, D7000, WNR3500, R6400 and R6800, WNDR3800, but is likely to be compatible
+EX2700, EX6120, EX6150v2, DNG3700v2, R6100, R6220, R7000, D7000, WNR3500, R6400 and R6800, WNDR3800, but is likely to be compatible
 with many other Netgear devices.
 
 Prebuilt binaries for Linux, ~OS X~ macOS and Windows are available


### PR DESCRIPTION
Went back from OpenWRT 19.07.3 to OEM firmware 1.2.0.4 (China) using nmrpflash.
After a few times of retries, router finally answered nmrpflash and recieved my firmware image.
"Timeout while waiting for ACK(0)/OACK" occured the first time and did not occur again.