### PR TITLE
Confirmed working on R6020

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ nmrpflash - Netgear Unbrick Utility
 
 `nmrpflash` uses Netgear's [NMRP protocol](http://www.chubb.wattle.id.au/PeterChubb/nmrp.html)
 to flash a new firmware image to a compatible device. It has been successfully used with the
-Netgear D7000, DNG3700v2, EX2700, EX6100v2, EX6120, EX6150v2, R6080, R6100, R6220, R6400, R7000, R7000P
+Netgear D7000, DNG3700v2, EX2700, EX6100v2, EX6120, EX6150v2, R6020, R6080, R6100, R6220, R6400, R7000, R7000P
 R6800, R8000, R8000P, R8500, WNDR3800, WNDR4300, WNDR4500v3 WNR3500, but is likely to be compatible with
 many other Netgear devices as well.
 


### PR DESCRIPTION
Program helped me unbrick my NetGear R6020 AC750 Dual Band WiFi Router


```
$ nmrpflash.exe -i net3 -f R6020_V1.0.0.54.img
Waiting for Ethernet connection (Ctrl-C to skip).
Advertising NMRP server on net3 ... -
Received configuration request from 00:00:00:00:00:00.
Sending configuration: 10.***.***.***/24.
Received upload request without filename.
Uploading R6020_V1.0.0.54.img ... OK (7292217 b)
Waiting for remote to respond.
Received keep-alive request (5).
Remote finished. Closing connection.
Reboot your device now.
```

Official flash from website comes in .zip package, make sure to extract the .img out of it and flash that instead.
nmrpflash helped me flash stock firmware onto my R6020 with no errors, no issues, no hassle. I'm actually quite surprised it worked so well.